### PR TITLE
Use hostname instead of host for ldap

### DIFF
--- a/selfservice/__init__.py
+++ b/selfservice/__init__.py
@@ -66,7 +66,7 @@ ldap = CSHLDAP(app.config["LDAP_BIND_DN"], app.config["LDAP_BIND_PW"])
 
 # Find FreeIPA server
 ldap_srvs = srvlookup.lookup("ldap", "tcp", "csh.rit.edu")
-ldap_uri = ldap_srvs[0].host
+ldap_uri = ldap_srvs[0].hostname
 
 # FreeIPA API Connection
 ipa = Client(ldap_uri, version="2.215")

--- a/selfservice/utilities/reset.py
+++ b/selfservice/utilities/reset.py
@@ -110,7 +110,7 @@ def passwd_reset(username, password):
 
     # Find FreeIPA server
     ldap_srvs = srvlookup.lookup("ldap", "tcp", "csh.rit.edu")
-    ldap_uri = ldap_srvs[0].host
+    ldap_uri = ldap_srvs[0].hostname
     l = ldap.initialize("ldaps://{}".format(ldap_uri))
     l.simple_bind_s(app.config["LDAP_BIND_DN"], app.config["LDAP_BIND_PW"])
     l.modify_s(dn, [(ldap.MOD_REPLACE, "userPassword", [password.encode()])])
@@ -135,7 +135,7 @@ def passwd_change(username, old_pw, new_pw):
     """
     # Find FreeIPA server
     ldap_srvs = srvlookup.lookup("ldap", "tcp", "csh.rit.edu")
-    ldap_uri = ldap_srvs[0].host
+    ldap_uri = ldap_srvs[0].hostname
     change = requests.post(
         "https://{}/ipa/session/change_password".format(ldap_uri),
         data={"user": username, "old_password": old_pw, "new_password": new_pw},


### PR DESCRIPTION
Using host instead of hostname may return an ip, so TLS certificate checking will fail. This ensures the hostname is used so the certificate CN matches. 

Raised by https://sentry.io/organizations/csh/issues/1367294444/?referrer=slack